### PR TITLE
Adds support to execute ginkgo tests on terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 		getConfiguration().get('updateOn', defaultUpdateOn),
 		getConfiguration().get('updateOnTypeDelay', defaultUpdateOnTypeDelay),
 		getConfiguration().get('doubleClickThreshold', defaultDoubleClickThreshold),
+		getConfiguration().get('ginkgoPath', defaultGinkgoPath),
 	);
 	ctx.subscriptions.push(vscode.window.registerTreeDataProvider('ginkgotools.views.outline', ginkgoTreeDataProvider));
 	ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(evt => {
@@ -73,6 +74,9 @@ export function activate(ctx: vscode.ExtensionContext) {
 		}
 		if (affectsConfiguration(evt, 'doubleClickThreshold')) {
 			ginkgoTreeDataProvider.setDoubleClickThreshold(getConfiguration().get('doubleClickThreshold', defaultDoubleClickThreshold));
+		}
+		if (affectsConfiguration(evt, 'ginkgoPath')) {
+			ginkgoTreeDataProvider.setGinkgoPath(getConfiguration().get('ginkgoPath', defaultGinkgoPath));
 		}
 	}));
 }

--- a/src/outliner.ts
+++ b/src/outliner.ts
@@ -20,7 +20,7 @@ export interface GinkgoNode {
     pending: boolean;
 
     nodes: GinkgoNode[];
-    parent: GinkgoNode;
+    parent?: GinkgoNode;
 }
 
 export function preOrder(node: GinkgoNode, f: Function): void {

--- a/src/outliner.unit.test.ts
+++ b/src/outliner.unit.test.ts
@@ -29,7 +29,7 @@ describe('outline.fromJSON', function () {
         for (let tn of got.nested) {
             for (let c of tn.nodes) {
                 outliner.preOrder(c, function (n: outliner.GinkgoNode) {
-                    expect(n.parent.nodes).includes(n, `node ${util.inspect(n, false, 1)} is not a child of its parent, ${util.inspect(n.parent, false, 1)}`);
+                    expect(n.parent?.nodes).includes(n, `node ${util.inspect(n, false, 1)} is not a child of its parent, ${util.inspect(n.parent, false, 1)}`);
                 });
             }
         }

--- a/src/specExecutor.ts
+++ b/src/specExecutor.ts
@@ -1,0 +1,42 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { GinkgoNode } from './outliner';
+
+export class SpecExecutor {
+
+    constructor(private ginkgoPath: string, private element: GinkgoNode, private testFileName: string) { };
+
+    public executeTestSpec(terminal: vscode.Terminal | undefined, outputChannel: vscode.OutputChannel) {
+        let specText = '';
+        if (this.element.text !== '') {
+            specText = getFullSpecText(this.element);
+        }
+
+        if (specText !== '') {
+            if (terminal) {
+                const fileNameSplited = this.testFileName.split('/');
+                fileNameSplited.pop();
+                const folderPath = fileNameSplited.join('/');
+                terminal.sendText(`${this.ginkgoPath} -focus "${specText}" -r "${folderPath}"`, true);
+            } else {
+                outputChannel.appendLine("Terminal is not opened, so we can't run the gingko test command");
+            }
+        }
+    }
+}
+
+export function getFullSpecText(element: GinkgoNode): string {
+    let specText = '';
+    if (element.name.includes('When')) {
+        specText = 'when ' + element.text;
+    } else {
+        specText = element.text;
+    }
+
+    if (element.parent) {
+        return getFullSpecText(element.parent) + ' ' + specText;
+    }
+
+    return specText;
+}

--- a/src/specExecutor.unit.test.ts
+++ b/src/specExecutor.unit.test.ts
@@ -1,0 +1,84 @@
+'use strict';
+
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { GinkgoNode } from './outliner';
+import * as specExecutor from './specExecutor';
+
+const buildEmptyGinkgoNode = function () : GinkgoNode {
+    return {
+        name: '',
+        text: '',
+        start: 0,
+        end: 0,
+        spec: false,
+        focused: false,
+        pending: false,
+        nodes: [],
+        parent: undefined,
+    };
+};
+
+describe('specExecutor.getFullSpecText', function () {
+    let rootNode: GinkgoNode;
+    let node2: GinkgoNode;
+    let node3: GinkgoNode;
+    let node4: GinkgoNode;
+
+    beforeEach(function () {
+        rootNode = buildEmptyGinkgoNode();
+        rootNode.name = 'Describe';
+        rootNode.text = 'MyClass';
+
+        node2 = buildEmptyGinkgoNode();
+        node2.name = 'Context';
+        node2.text = 'Creating a new stuff';
+        node2.parent = rootNode;
+
+        node3 = buildEmptyGinkgoNode();
+        node3.name = 'When';
+        node3.text = 'Have a some data';
+        node3.parent = node2;
+
+        node4 = buildEmptyGinkgoNode();
+        node4.name = 'It';
+        node4.text = 'should return success';
+        node4.parent = node3;
+    });
+
+    context("when we have 4 nested nodes", function () {
+        it('should return the text to the last node properly', function () {
+            const result = specExecutor.getFullSpecText(node4);
+            expect(result).to.equal("MyClass Creating a new stuff when Have a some data should return success");
+        });
+
+        it('should return the text to the 3th node properly', function () {
+            const result = specExecutor.getFullSpecText(node3);
+            expect(result).to.equal("MyClass Creating a new stuff when Have a some data");
+        });
+
+        it('should return the text to the 2th node properly', function () {
+            const result = specExecutor.getFullSpecText(node2);
+            expect(result).to.equal("MyClass Creating a new stuff");
+        });
+
+        it('should return the text to the root node properly', function () {
+            const result = specExecutor.getFullSpecText(rootNode);
+            expect(result).to.equal("MyClass");
+        });
+    });
+
+    context("when we have name variants for 'When'", function () {
+        it("should return the text properly for 'FWhen'", function () {
+            node3.name = 'FWhen';
+            const result = specExecutor.getFullSpecText(node4);
+            expect(result).to.equal("MyClass Creating a new stuff when Have a some data should return success");
+        });
+
+        it("should return the text properly for 'PWhen'", function () {
+            node3.name = 'PWhen';
+            const result = specExecutor.getFullSpecText(node4);
+            expect(result).to.equal("MyClass Creating a new stuff when Have a some data should return success");
+        });
+    });
+});


### PR DESCRIPTION
Firstly, thank you for this plugin, it helped me and I loved it. =)
I was searching for something like that and that works, and this one works very well.

The idea of this PR is after a double click on the TreeView, execute the test of the Spec clicked on the active terminal.
If no one terminal is active, the test is no executed and a message is sent to the outputChannel.
If an `It` element is selected/clicked only its test is executed, if a `When` or `Context` or `Describe` element is selected, all nested are executed.

I had some problems creating unit tests for the code that invokes `vscode` module, so I avoid calling it inside the method tested, and I tested only one method. =(

If you liked it and think it like interesting to have it in the master branch, I'll create a gif to put in the README with an test execution example.